### PR TITLE
handle the case where SSLv3 is disabled

### DIFF
--- a/wr_extensions/nopoll-0.2.7.b164/src/nopoll_conn.c
+++ b/wr_extensions/nopoll-0.2.7.b164/src/nopoll_conn.c
@@ -688,8 +688,12 @@ SSL_CTX * __nopoll_conn_get_ssl_context (noPollCtx * ctx, noPollConn * conn, noP
                 break;
 #endif
 	case NOPOLL_METHOD_SSLV3:
+#if !defined(OPENSSL_NO_SSL3_METHOD)
 		/* printf ("**** REPORTING SSLv3 ****\n"); */
 		return SSL_CTX_new (is_client ? SSLv3_client_method () : SSLv3_server_method ()); 
+#else
+                break;
+#endif
 	case NOPOLL_METHOD_SSLV23:
 		/* printf ("**** REPORTING SSLv23 ****\n"); */
 		return SSL_CTX_new (is_client ? SSLv23_client_method () : SSLv23_server_method ()); 


### PR DESCRIPTION
Without this, I get
nopoll_conn.c: In function ‘__nopoll_conn_get_ssl_context’:
nopoll_conn.c:692:35: error: implicit declaration of function ‘SSLv3_client_method’ [-Werror=implicit-function-declaration]
   return SSL_CTX_new (is_client ? SSLv3_client_method () : SSLv3_server_method ());
                                   ^~~~~~~~~~~~~~~~~~~
nopoll_conn.c:692:60: error: implicit declaration of function ‘SSLv3_server_method’ [-Werror=implicit-function-declaration]
   return SSL_CTX_new (is_client ? SSLv3_client_method () : SSLv3_server_method ());
                                                            ^~~~~~~~~~~~~~~~~~~
nopoll_conn.c:692:23: error: passing argument 1 of ‘SSL_CTX_new’ makes pointer from integer without a cast [-Werror=int-conversion]
   return SSL_CTX_new (is_client ? SSLv3_client_method () : SSLv3_server_method ());
                       ^~~~~~~~~
In file included from ./nopoll_private.h:46:0,
                 from nopoll_conn.c:50:
/usr/include/openssl/ssl.h:2131:10: note: expected ‘const SSL_METHOD * {aka const struct ssl_method_st *}’ but argument is of type ‘int’
 SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);


Still need to update the nopoll-0.2.7.b164.tar.gz archive.
